### PR TITLE
fix:update object type title description

### DIFF
--- a/frontend/src/components/elements/MMUModalEdit.tsx
+++ b/frontend/src/components/elements/MMUModalEdit.tsx
@@ -173,7 +173,7 @@ export const MMUModalEdit = <T extends { id: number, origin?: manifestOrigin | m
       title: newItemTitle,
       description: newItemDescription,
     }
-    if (objectTypes !== ObjectTypes.GROUP) {
+    if (objectTypes !== ObjectTypes.GROUP&&objectTypes&&selectedMetadataFormat?.title) {
       await createMetadataForItem( objectTypes! ,item.id, selectedMetadataFormat!.title,selectedMetadataData  );
     }
     if (updateItem) {


### PR DESCRIPTION
resolve: #340 
Problem: When editing the object type title or description, it doesn't work. I think this happens because the metadataFormat is undefined. In #340 , I added more information.

Solution: When either of the two values is undefined, the first condition is still being entered, which causes an error. To fix this, I updated the condition to ensure both values are not nullable before proceeding.