### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Frontend & Backend Build Check
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/TETRAS-IIIF/mirador-multi-user/security/code-scanning/3](https://github.com/TETRAS-IIIF/mirador-multi-user/security/code-scanning/3)

In general, the fix is to explicitly declare `permissions` either at the workflow root or per job, granting only what is required. Since this workflow only checks out code and runs Node-based builds and audits, it needs read access to repository contents and nothing else. The recommended minimal configuration is `permissions: contents: read`, either at the root or under `jobs.build`.

The single best fix with minimal functional impact is to add a `permissions:` block just under `name:` at the top level of `.github/workflows/build.yml`. This will apply to all jobs in the workflow (currently only `build`) and restrict the `GITHUB_TOKEN` to read-only contents. Concretely, after line 1 (`name: Frontend & Backend Build Check`), insert:

```yaml
permissions:
  contents: read
```

No imports or other code changes are necessary; this is purely a YAML configuration change within the same file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
